### PR TITLE
Add dpad override option to better emulate console behavior for Under Night on pc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,9 @@ jobs:
           name: Generate build files
           command: ./build/generate.sh
       - run:
+          name: Use older version of memchr to prevent build errors
+          command: cargo update -p memchr --precise 2.3.4  
+      - run:
           name: Build 32-bit
           command: ninja -C build/i686 install
       - run:
@@ -32,6 +35,9 @@ jobs:
       - run:
           name: Generate build files
           command: ./build/generate.sh
+      - run:
+          name: Use older version of memchr to prevent build errors
+          command: cargo update -p memchr --precise 2.3.4  
       - run:
           name: Build 64-bit
           command: ninja -C build/x86_64 install

--- a/dhc/src/config.rs
+++ b/dhc/src/config.rs
@@ -23,6 +23,11 @@ static DEFAULT_CONFIG: &str = indoc!(r#"
   # Most games (i.e. any game that supports a PS4 controller) will want "directinput".
   mode = "directinput"
 
+
+  # This flag when enabled will make the dpad take priority over left stick
+  # to better emulate console behavior for games like PS4 UNI
+  dpad_override = false
+
   # Deadzone customization.
   # This allows you to set a threshold for left analog stick values.
   # Any x/y values (from 0 to 1) below it are snapped to the center.
@@ -31,10 +36,6 @@ static DEFAULT_CONFIG: &str = indoc!(r#"
   [deadzone]
   enabled = false
   threshold = 0.5
-  
-  # This flag when enabled will make the dpad take priority over left stick
-  # to better emulate console behavior for games like PS4 UNI
-  dpad_override = false
 "#);
 
 #[repr(C)]
@@ -64,8 +65,8 @@ pub struct Config {
   pub log_level: logger::LogLevel,
   pub device_count: usize,
   pub mode: EmulationMode,
-  pub deadzone: Option<DeadzoneConfig>,
   pub dpad_override: bool,
+  pub deadzone: Option<DeadzoneConfig>,
 }
 
 #[derive(Clone, Deserialize, Debug)]

--- a/dhc/src/config.rs
+++ b/dhc/src/config.rs
@@ -31,6 +31,10 @@ static DEFAULT_CONFIG: &str = indoc!(r#"
   [deadzone]
   enabled = false
   threshold = 0.5
+  
+  # This flag when enabled will make the dpad take priority over left stick
+  # to better emulate console behavior for games like PS4 UNI
+  dpad_override = false
 "#);
 
 #[repr(C)]
@@ -61,6 +65,7 @@ pub struct Config {
   pub device_count: usize,
   pub mode: EmulationMode,
   pub deadzone: Option<DeadzoneConfig>,
+  pub dpad_override: bool,
 }
 
 #[derive(Clone, Deserialize, Debug)]

--- a/dhc/src/input/types.rs
+++ b/dhc/src/input/types.rs
@@ -71,7 +71,7 @@ pub enum ButtonType {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug,PartialEq, Eq)]
 pub enum Hat {
   Neutral,
   North,

--- a/dhc/src/lib.rs
+++ b/dhc/src/lib.rs
@@ -264,6 +264,12 @@ impl Context {
 }
 
 pub(crate) fn mangle_inputs(inputs: &mut DeviceInputs) {
+  if CONFIG.dpad_override{
+    if inputs.get_hat(HatType::DPad) != Hat::Neutral{
+      inputs.axis_left_stick_x.set_value(0.5);
+      inputs.axis_left_stick_y.set_value(0.5);
+    }
+  }
   if let Some(deadzone_config) = &CONFIG.deadzone {
     if deadzone_config.enabled {
       for ref mut axis in &mut [&mut inputs.axis_left_stick_x, &mut inputs.axis_left_stick_y] {


### PR DESCRIPTION
Under Night on PS4 will always override left stick with DPAD. 
On steam this is not the case and it results in wierd issues when using both. 
This pr adds a `dpad_override` flag which when enabled will force dpad to override left stick.

This also fixes the CI builds thanks to a sub dependency bringing in a new version of `memchr`